### PR TITLE
🔧  Action description is too long

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,5 +1,5 @@
 name: 'Synchronize staging branch'
-description: 'Reset the staging branch with the main branch merging some branches identified by the labels containing the target branch name.'
+description: 'Reset the staging branch with the main branch merging some branches identified by a specific label.'
 inputs:
   repository:
     description: 'The repository name in Github owner/repository. e.g: TheMenu/monrepo'


### PR DESCRIPTION
To be published on the GitHub market place, the description should be less than 125 characters.